### PR TITLE
0.8.10 - Rework of the Rarity System

### DIFF
--- a/Items/Accessories/RedMistMask.cs
+++ b/Items/Accessories/RedMistMask.cs
@@ -27,7 +27,7 @@ namespace LobotomyCorp.Items.Accessories
             Item.height = 16;
             Item.accessory = true;
             Item.value = 1000;
-            Item.rare = ItemRarityID.Red;
+            Item.rare = ModContent.RarityType<AlephB>();
         }
 
         public override void UpdateAccessory(Player player, bool hideVisual)

--- a/Items/Aleph/Adoration.cs
+++ b/Items/Aleph/Adoration.cs
@@ -12,7 +12,7 @@ namespace LobotomyCorp.Items.Aleph
         public override void SetStaticDefaults()
         {
             /* Tooltip.SetDefault("A big mug filled with mysterious slime that never runs out.\n" +
-                               "ItÅ's the byproduct of some horrid experiment in a certain laboratory that eventually failed.\n" +
+                               "ItÔøΩ's the byproduct of some horrid experiment in a certain laboratory that eventually failed.\n" +
                                "Inflicts Slow"); */
         }
 
@@ -28,7 +28,7 @@ namespace LobotomyCorp.Items.Aleph
             Item.useStyle = ItemUseStyleID.Shoot;
             Item.knockBack = 4;
             Item.value = 8000;
-            Item.rare = ItemRarityID.Red;
+            Item.rare = ModContent.RarityType<AlephB>();
             //Item.UseSound = LobotomyCorp.WeaponSound("Slime");
             Item.autoReuse = true;
             Item.shoot = ModContent.ProjectileType<MeltyLove>();

--- a/Items/Aleph/Censored.cs
+++ b/Items/Aleph/Censored.cs
@@ -31,7 +31,7 @@ namespace LobotomyCorp.Items.Aleph
             Item.useStyle = 5;
 
             Item.value = 10000;
-            Item.rare = ItemRarityID.Red;
+            Item.rare = ModContent.RarityType<AlephB>();
             Item.autoReuse = true;
             Item.noMelee = true;
             Item.noUseGraphic = true;

--- a/Items/Aleph/DaCapo.cs
+++ b/Items/Aleph/DaCapo.cs
@@ -28,7 +28,7 @@ namespace LobotomyCorp.Items.Aleph
             Item.useStyle = 1;
             Item.knockBack = 6;
             Item.value = 10000;
-            Item.rare = ItemRarityID.Red;
+            Item.rare = ModContent.RarityType<AlephB>();
             Item.UseSound = SoundID.Item1;
             Item.autoReuse = true;
             Item.shoot = ModContent.ProjectileType<Projectiles.DaCapo>();

--- a/Items/Aleph/GoldRush.cs
+++ b/Items/Aleph/GoldRush.cs
@@ -29,7 +29,7 @@ namespace LobotomyCorp.Items.Aleph
             Item.useStyle = ItemUseStyleID.Shoot;
             Item.knockBack = 4;
             Item.value = 10000;
-            Item.rare = ItemRarityID.Red;
+            Item.rare = ModContent.RarityType<AlephB>();
             Item.shootSpeed = 11f;
             Item.shoot = ModContent.ProjectileType<Projectiles.GoldRushPunches>();
 

--- a/Items/Aleph/Justitia.cs
+++ b/Items/Aleph/Justitia.cs
@@ -28,7 +28,7 @@ namespace LobotomyCorp.Items.Aleph
             Item.useStyle = 15;
             Item.knockBack = 3;
             Item.value = 10000;
-            Item.rare = ItemRarityID.Red;
+            Item.rare = ModContent.RarityType<AlephB>();
             Item.UseSound = SoundID.Item1;
             Item.autoReuse = true;
             Item.shootSpeed = 16f;

--- a/Items/Aleph/Mimicry.cs
+++ b/Items/Aleph/Mimicry.cs
@@ -33,7 +33,7 @@ namespace LobotomyCorp.Items.Aleph
             Item.knockBack = 6;
             Item.value = 10000;
             Item.channel = true;
-            Item.rare = ItemRarityID.Red;
+            Item.rare = ModContent.RarityType<AlephB>();
             MimicryHeal = false;
             //Item.UseSound = SoundID.Item1;
             EGORiskLevel = RiskLevel.Aleph;

--- a/Items/Aleph/ParadiseLost.cs
+++ b/Items/Aleph/ParadiseLost.cs
@@ -31,7 +31,7 @@ namespace LobotomyCorp.Items.Aleph
             Item.noMelee = true;
             Item.knockBack = 0.8f;
             Item.value = 10000;
-            Item.rare = ItemRarityID.Red;
+            Item.rare = ModContent.RarityType<AlephB>();
             Item.UseSound = LobotomyCorp.WeaponSound("DeathAngel1");
             Item.autoReuse = true;
             Item.shoot = ModContent.ProjectileType<Projectiles.ParadiseLostBase>();

--- a/Items/Aleph/Pink.cs
+++ b/Items/Aleph/Pink.cs
@@ -28,7 +28,7 @@ namespace LobotomyCorp.Items.Aleph
             Item.noMelee = true; //so the Item's animation doesn't do damage
             Item.knockBack = 4; // Sets the Item's knockback. Note that projectiles shot by this weapon will use its and the used ammunition's knockback damageed together.
             Item.value = 10000; // how much the Item sells for (measured in copper)
-            Item.rare = ItemRarityID.Red; // the color that the Item's name will be in-game
+            Item.rare = ModContent.RarityType<AlephB>(); // the color that the Item's name will be in-game
             Item.UseSound = LobotomyCorp.WeaponSounds.Rifle; // The sound that this Item plays when used.
             Item.autoReuse = true; // if you can hold click to automatically use it again
             Item.shoot = 10; //idk why but all the guns in the vanilla source have this

--- a/Items/Aleph/Smile.cs
+++ b/Items/Aleph/Smile.cs
@@ -32,7 +32,7 @@ namespace LobotomyCorp.Items.Aleph
 
             Item.knockBack = 6;
             Item.value = 10000;
-            Item.rare = ItemRarityID.Red;
+            Item.rare = ModContent.RarityType<AlephB>();
 
             SwingSound = LobotomyCorp.WeaponSounds.Hammer;
             Item.autoReuse = true;

--- a/Items/Aleph/SoundOfAStar.cs
+++ b/Items/Aleph/SoundOfAStar.cs
@@ -31,7 +31,7 @@ namespace LobotomyCorp.Items.Aleph
             Item.noMelee = true;
             Item.knockBack = 2.4f;
             Item.value = 5000;
-            Item.rare = ItemRarityID.Red;
+            Item.rare = ModContent.RarityType<AlephB>();
             Item.UseSound = LobotomyCorp.WeaponSound("blueStar");
             Item.autoReuse = true;
             Item.shoot = ModContent.ProjectileType<Projectiles.SoundOfAStar>();

--- a/Items/Aleph/Twilight.cs
+++ b/Items/Aleph/Twilight.cs
@@ -32,7 +32,7 @@ namespace LobotomyCorp.Items.Aleph
             Item.useStyle = 15;
             Item.knockBack = 6;
             Item.value = 10000;
-            Item.rare = ItemRarityID.Red;
+            Item.rare = ModContent.RarityType<AlephB>();
             Item.UseSound = SoundID.Item1;
             Item.autoReuse = true;
 

--- a/Items/Armor/SodaSuit.cs
+++ b/Items/Armor/SodaSuit.cs
@@ -29,7 +29,7 @@ namespace LobotomyCorp.Items.Armor
             Item.height = 40;
             Item.useTime = 56;
             Item.value = 10000;
-            Item.rare = ItemRarityID.Green;
+            Item.rare = ModContent.RarityType<ZayinB>();
             EGORiskLevel = RiskLevel.Zayin;
         }
     }
@@ -49,7 +49,7 @@ namespace LobotomyCorp.Items.Armor
             Item.height = 40;
             Item.useTime = 56;
             Item.value = 10000;
-            Item.rare = ItemRarityID.Green;
+            Item.rare = ModContent.RarityType<ZayinB>();
             EGORiskLevel = RiskLevel.Zayin;
         }
     }
@@ -69,7 +69,7 @@ namespace LobotomyCorp.Items.Armor
             Item.height = 40;
             Item.useTime = 56;
             Item.value = 10000;
-            Item.rare = ItemRarityID.Green;
+            Item.rare = ModContent.RarityType<ZayinB>();
             EGORiskLevel = RiskLevel.Zayin;
         }
     }

--- a/Items/Armor/WingbeatSuit.cs
+++ b/Items/Armor/WingbeatSuit.cs
@@ -29,7 +29,7 @@ namespace LobotomyCorp.Items.Armor
             Item.height = 40;
             Item.useTime = 56;
             Item.value = 10000;
-            Item.rare = ItemRarityID.Green;
+            Item.rare = ModContent.RarityType<ZayinB>();
             EGORiskLevel = RiskLevel.Zayin;
         }
     }
@@ -49,7 +49,7 @@ namespace LobotomyCorp.Items.Armor
             Item.height = 40;
             Item.useTime = 56;
             Item.value = 10000;
-            Item.rare = ItemRarityID.Green;
+            Item.rare = ModContent.RarityType<ZayinB>();
             EGORiskLevel = RiskLevel.Zayin;
         }
     }
@@ -69,7 +69,7 @@ namespace LobotomyCorp.Items.Armor
             Item.height = 40;
             Item.useTime = 56;
             Item.value = 10000;
-            Item.rare = ItemRarityID.Green;
+            Item.rare = ModContent.RarityType<ZayinB>();
             EGORiskLevel = RiskLevel.Zayin;
         }
     }

--- a/Items/He/BearPaw.cs
+++ b/Items/He/BearPaw.cs
@@ -11,7 +11,7 @@ namespace LobotomyCorp.Items.He
         public override void SetStaticDefaults()
         {
             /* Tooltip.SetDefault("Its adorable appearance makes it something that might even appeal to a child as a gift.\n" +
-                               "Do not underestimate the weaponÅ's power because of its fluffy exterior."); */
+                               "Do not underestimate the weaponÔøΩ's power because of its fluffy exterior."); */
         }
 
         public override void SetDefaults()
@@ -23,7 +23,7 @@ namespace LobotomyCorp.Items.He
             Item.useTime = 12;
             Item.autoReuse = true;
             Item.UseSound = LobotomyCorp.WeaponSounds.Fist;
-            Item.rare = ItemRarityID.Yellow;
+            Item.rare = ModContent.RarityType<HeB>();
             EGORiskLevel = RiskLevel.He;
         }
         /*

--- a/Items/He/Christmas.cs
+++ b/Items/He/Christmas.cs
@@ -28,7 +28,7 @@ namespace LobotomyCorp.Items.He
             Item.useStyle = 15;
             Item.knockBack = 6;
             Item.value = 5000;
-            Item.rare = ItemRarityID.Yellow;
+            Item.rare = ModContent.RarityType<HeB>();
             Item.UseSound = LobotomyCorp.WeaponSounds.Mace;
             Item.autoReuse = true;
 

--- a/Items/He/FrostSplinter.cs
+++ b/Items/He/FrostSplinter.cs
@@ -30,7 +30,7 @@ namespace LobotomyCorp.Items.He
             Item.useStyle = ItemUseStyleID.Shoot;
             Item.knockBack = 6;
             Item.value = 10000;
-            Item.rare = ItemRarityID.Yellow;
+            Item.rare = ModContent.RarityType<HeB>();
             Item.shootSpeed = 4.7f;
             Item.shoot = ModContent.ProjectileType<Projectiles.FrostSplinter>();
 

--- a/Items/He/Gaze.cs
+++ b/Items/He/Gaze.cs
@@ -29,7 +29,7 @@ namespace LobotomyCorp.Items.He
             Item.useStyle = ItemUseStyleID.Shoot;
             Item.knockBack = 2;
             Item.value = 10000;
-            Item.rare = ItemRarityID.Yellow;
+            Item.rare = ModContent.RarityType<HeB>();
             Item.shootSpeed = 2.2f;
             Item.shoot = ModContent.ProjectileType<Projectiles.Gaze>();
 

--- a/Items/He/GrinderMk4.cs
+++ b/Items/He/GrinderMk4.cs
@@ -28,7 +28,7 @@ namespace LobotomyCorp.Items.He
             Item.useStyle = ItemUseStyleID.Shoot;
             Item.knockBack = 2;
             Item.value = 10000;
-            Item.rare = ItemRarityID.Yellow;
+            Item.rare = ModContent.RarityType<HeB>();
             Item.shootSpeed = 1.8f;
             Item.shoot = ModContent.ProjectileType<Projectiles.GrinderMk4>();
 

--- a/Items/He/Harmony.cs
+++ b/Items/He/Harmony.cs
@@ -29,7 +29,7 @@ namespace LobotomyCorp.Items.He
             Item.noMelee = true; //so the Item's animation doesn't do damage
             Item.knockBack = 4; // Sets the Item's knockback. Note that projectiles shot by this weapon will use its and the used ammunition's knockback damageed together.
             Item.value = 10000; // how much the Item sells for (measured in copper)
-            Item.rare = ItemRarityID.Yellow; // the color that the Item's name will be in-game
+            Item.rare = ModContent.RarityType<HeB>(); // the color that the Item's name will be in-game
             Item.UseSound = LobotomyCorp.WeaponSounds.Cannon; // The sound that this Item plays when used.
             Item.autoReuse = true; // if you can hold click to automatically use it again
             Item.shoot = 10; //idk why but all the guns in the vanilla source have this

--- a/Items/He/Harvest.cs
+++ b/Items/He/Harvest.cs
@@ -28,7 +28,7 @@ namespace LobotomyCorp.Items.He
             Item.useStyle = ItemUseStyleID.Shoot;
             Item.knockBack = 6;
             Item.value = 10000;
-            Item.rare = ItemRarityID.Yellow;
+            Item.rare = ModContent.RarityType<HeB>();
             Item.shootSpeed = 4.7f;
             Item.shoot = ModContent.ProjectileType<Projectiles.Harvest>();
 

--- a/Items/He/Laetitia.cs
+++ b/Items/He/Laetitia.cs
@@ -25,7 +25,7 @@ namespace LobotomyCorp.Items.He
             Item.noMelee = true; //so the Item's animation doesn't do damage
             Item.knockBack = 4; // Sets the Item's knockback. Note that projectiles shot by this weapon will use its and the used ammunition's knockback damageed together.
             Item.value = 10000; // how much the Item sells for (measured in copper)
-            Item.rare = ItemRarityID.Yellow; // the color that the Item's name will be in-game
+            Item.rare = ModContent.RarityType<HeB>(); // the color that the Item's name will be in-game
             Item.UseSound = LobotomyCorp.WeaponSounds.Rifle; // The sound that this Item plays when used.
             Item.autoReuse = true; // if you can hold click to automatically use it again
             Item.shoot = 10; //idk why but all the guns in the vanilla source have this

--- a/Items/He/LifeForADaredevil.cs
+++ b/Items/He/LifeForADaredevil.cs
@@ -20,7 +20,7 @@ namespace LobotomyCorp.Items.He
             Item.useStyle = 15;
             Item.damage = 32;
             Item.DamageType = DamageClass.Generic;
-            Item.rare = ItemRarityID.Yellow;
+            Item.rare = ModContent.RarityType<HeB>();
             Item.UseSound = LobotomyCorp.WeaponSound("katana");
             EGORiskLevel = RiskLevel.He;
         }

--- a/Items/He/Lumber.cs
+++ b/Items/He/Lumber.cs
@@ -25,7 +25,7 @@ namespace LobotomyCorp.Items.He
             Item.useStyle = 15;
             Item.knockBack = 6;
             Item.value = 10000;
-            Item.rare = ItemRarityID.Yellow;
+            Item.rare = ModContent.RarityType<HeB>();
             SwingSound = new SoundStyle("LobotomyCorp/Sounds/Item/Lumberjack_Atk2") with { Volume = 0.5f, PitchVariance = 0.1f }; ;
             Item.autoReuse = true;
             EGORiskLevel = RiskLevel.He;

--- a/Items/He/OurGalaxy.cs
+++ b/Items/He/OurGalaxy.cs
@@ -28,7 +28,7 @@ namespace LobotomyCorp.Items.He
             Item.useStyle = 15;
             Item.knockBack = 6;
             Item.value = 10000;
-            Item.rare = ItemRarityID.Yellow;
+            Item.rare = ModContent.RarityType<HeB>();
             Item.shoot = ModContent.ProjectileType<Projectiles.OurGalaxySparkle>();
             Item.shootSpeed = 10f;
             Item.UseSound = LobotomyCorp.WeaponSound("Galaxy");

--- a/Items/He/SanguineDesire.cs
+++ b/Items/He/SanguineDesire.cs
@@ -23,7 +23,7 @@ namespace LobotomyCorp.Items.He
             Item.useStyle = 15;
             Item.knockBack = 6;
             Item.value = 10000;
-            Item.rare = ItemRarityID.Yellow;
+            Item.rare = ModContent.RarityType<HeB>();
             Item.UseSound = LobotomyCorp.WeaponSounds.Axe;
             Item.autoReuse = true;
             Item.scale = 0.7f;

--- a/Items/He/ScreamingWedge.cs
+++ b/Items/He/ScreamingWedge.cs
@@ -26,7 +26,7 @@ namespace LobotomyCorp.Items.He
             Item.noMelee = true;
             Item.knockBack = 4;
             Item.value = 10000;
-            Item.rare = ItemRarityID.Yellow;
+            Item.rare = ModContent.RarityType<HeB>();
             Item.UseSound = LobotomyCorp.WeaponSounds.BowGun;
             Item.autoReuse = true;
             Item.shoot = 10;

--- a/Items/He/Syrinx.cs
+++ b/Items/He/Syrinx.cs
@@ -29,7 +29,7 @@ namespace LobotomyCorp.Items.He
             Item.noMelee = true;
             Item.knockBack = 4;
             Item.value = 10000;
-            Item.rare = ItemRarityID.Yellow;
+            Item.rare = ModContent.RarityType<HeB>();
             Item.UseSound = new SoundStyle("LobotomyCorp/Sounds/Item/LWeapons/fetus", 3) with { Volume = 0.5f, MaxInstances = 1, SoundLimitBehavior = SoundLimitBehavior.IgnoreNew };
             Item.autoReuse = true;
             Item.shoot = ModContent.ProjectileType<Projectiles.SyrinxSound>();

--- a/Items/NonEgo/MagicBulletBullet.cs
+++ b/Items/NonEgo/MagicBulletBullet.cs
@@ -19,7 +19,7 @@ namespace LobotomyCorp.Items.NonEgo
 			Item.consumable = true; // This marks the item as consumable, making it automatically be consumed when it's used as ammunition, or something else, if possible.
 			Item.knockBack = 1.5f;
 			Item.value = 10;
-			Item.rare = ItemRarityID.Purple;
+			Item.rare = ModContent.RarityType<WawB>();
 			Item.shoot = ModContent.ProjectileType<Projectiles.MagicBulletBullet>(); // The projectile that weapons fire when using this item as ammunition.
 			Item.shootSpeed = 12f; // The speed of the projectile. This value equivalent to Silver Bullet since ExampleBullet's Projectile.extraUpdates is 1.
 			Item.ammo = AmmoID.Bullet; // The ammo class this ammo belongs to.

--- a/Items/Ruina/Art/DaCapoR.cs
+++ b/Items/Ruina/Art/DaCapoR.cs
@@ -26,7 +26,7 @@ namespace LobotomyCorp.Items.Ruina.Art
 			Item.useStyle = 15;
 			Item.knockBack = 5;
 			Item.value = 10000;
-		    Item.rare = 2;
+		    Item.rare = ModContent.RarityType<AlephR>();
             Item.UseSound = null;
 			Item.autoReuse = true;
             Item.shoot = ModContent.ProjectileType<DaCapoMusicSlash>();

--- a/Items/Ruina/Art/FaintAromaR.cs
+++ b/Items/Ruina/Art/FaintAromaR.cs
@@ -35,7 +35,7 @@ namespace LobotomyCorp.Items.Ruina.Art
 			Item.useStyle = ItemUseStyleID.HoldUp;
 			Item.knockBack = 0;
 			Item.value = 10000;
-			Item.rare = 2;
+			Item.rare = ModContent.RarityType<WawR>();
 			Item.UseSound = SoundID.Item1;
 			Item.autoReuse = true;
             Item.shoot = ModContent.ProjectileType<Projectiles.AlriuneDeathAnimation>();

--- a/Items/Ruina/Art/FragmentsFromSomewhereR.cs
+++ b/Items/Ruina/Art/FragmentsFromSomewhereR.cs
@@ -37,7 +37,7 @@ namespace LobotomyCorp.Items.Ruina.Art
 			//Item.UseSound = SoundID.Item1;
 			Item.autoReuse = true;
 			Item.channel = true;
-			Item.rare = ItemRarityID.Yellow;
+			Item.rare = ModContent.RarityType<TethR>();
 
 			Item.shoot = ModContent.ProjectileType<Projectiles.Realized.FragmentsFromSomewhereRSpear>();
 			Item.shootSpeed = 5.6f;

--- a/Items/Ruina/Art/OurGalaxyR.cs
+++ b/Items/Ruina/Art/OurGalaxyR.cs
@@ -36,7 +36,7 @@ namespace LobotomyCorp.Items.Ruina.Art
             Item.noUseGraphic = true;
 			Item.UseSound = new SoundStyle("LobotomyCorp/Sounds/Item/Art/Galaxy_Strong_Big_Shot") with { Volume = 0.25f };
             Item.autoReuse = true;
-			Item.rare = ItemRarityID.Yellow;
+			Item.rare = ModContent.RarityType<HeR>();
 
 			Item.shoot = ModContent.ProjectileType<Projectiles.Realized.OurGalaxyComet>();
 			Item.shootSpeed = 14;

--- a/Items/Ruina/Art/PleasureR.cs
+++ b/Items/Ruina/Art/PleasureR.cs
@@ -38,7 +38,7 @@ namespace LobotomyCorp.Items.Ruina.Art
             Item.noUseGraphic = true;
 			//Item.UseSound = SoundID.Item1;
 			Item.autoReuse = true;
-			Item.rare = ItemRarityID.Yellow;
+			Item.rare = ModContent.RarityType<HeR>();
 
 			Item.shoot = ModContent.ProjectileType<Projectiles.Realized.PleasureSpike>();
 			Item.shootSpeed = 12;

--- a/Items/Ruina/History/ForgottenR.cs
+++ b/Items/Ruina/History/ForgottenR.cs
@@ -42,7 +42,7 @@ namespace LobotomyCorp.Items.Ruina.History
 			Item.useStyle = -1;
 			Item.knockBack = 6;
 			Item.value = 10000;
-			Item.rare = 2;
+			Item.rare = ModContent.RarityType<HeR>();
 			Item.UseSound = SoundID.Item1;
             Item.shoot = ModContent.ProjectileType<Projectiles.Realized.ForgottenR>();
             Item.shootSpeed = 1f;

--- a/Items/Ruina/History/FourthMatchFlameR.cs
+++ b/Items/Ruina/History/FourthMatchFlameR.cs
@@ -36,7 +36,7 @@ namespace LobotomyCorp.Items.Ruina.History
 			Item.useStyle = 1;
 			Item.knockBack = 6;
 			Item.value = 10000;
-			Item.rare = 2;
+			Item.rare = ModContent.RarityType<TethR>();
 			Item.UseSound = SoundID.Item1;
             Item.shoot = ModContent.ProjectileType<Projectiles.FourthMatchFlameGigaSlash>();
             Item.shootSpeed = 1f;

--- a/Items/Ruina/History/GreenStemR.cs
+++ b/Items/Ruina/History/GreenStemR.cs
@@ -22,7 +22,7 @@ namespace LobotomyCorp.Items.Ruina.History
             EgoColor = LobotomyCorp.WawRarity;
 
             Item.damage = 48;
-            Item.DamageType = DamageClass.Magic;;
+            Item.DamageType = DamageClass.Magic;
             Item.width = 40;
             Item.height = 40;
 
@@ -32,7 +32,7 @@ namespace LobotomyCorp.Items.Ruina.History
             Item.useStyle = ItemUseStyleID.Shoot;
             Item.knockBack = 0;
             Item.value = 10000;
-            Item.rare = 2;
+            Item.rare = ModContent.RarityType<WawR>();
             Item.shootSpeed = 1f;
             Item.shoot = ModContent.ProjectileType<Projectiles.GreenStemArea>();
             

--- a/Items/Ruina/History/HornetR.cs
+++ b/Items/Ruina/History/HornetR.cs
@@ -28,7 +28,7 @@ namespace LobotomyCorp.Items.Ruina.History
 			Item.useStyle = ItemUseStyleID.Shoot;
 			Item.knockBack = 6;
 			Item.value = 10000;
-			Item.rare = 2;
+			Item.rare = ModContent.RarityType<WawR>();
 			Item.UseSound = SoundID.Item1;
             Item.noMelee = true;
             Item.noUseGraphic = true;

--- a/Items/Ruina/History/WingbeatR.cs
+++ b/Items/Ruina/History/WingbeatR.cs
@@ -40,7 +40,7 @@ namespace LobotomyCorp.Items.Ruina.History
 			Item.useStyle = ItemUseStyleID.Shoot;
 			Item.knockBack = 0;
 			Item.value = 10000;
-			Item.rare = 2;
+			Item.rare = ModContent.RarityType<ZayinR>();
             Item.shootSpeed = 16f;
             Item.shoot = ModContent.ProjectileType<Projectiles.WingbeatR>();
 

--- a/Items/Ruina/Language/MimicryR.cs
+++ b/Items/Ruina/Language/MimicryR.cs
@@ -28,7 +28,7 @@ namespace LobotomyCorp.Items.Ruina.Language
 			Item.useStyle = ItemUseStyleID.Shoot;
 			Item.knockBack = 6;
 			Item.value = 10000;
-			Item.rare = 2;
+			Item.rare = ModContent.RarityType<AlephR>();
 			//Item.UseSound = new SoundStyle("LobotomyCorp/Sounds/Item/NothingThere_Goodbye");
             Item.autoReuse = true;
             Item.noMelee = true;

--- a/Items/Ruina/Language/SmileR.cs
+++ b/Items/Ruina/Language/SmileR.cs
@@ -29,7 +29,7 @@ namespace LobotomyCorp.Items.Ruina.Language
 			Item.useStyle = ItemUseStyleID.Shoot;
 			Item.knockBack = 6;
 			Item.value = 10000;
-			Item.rare = ItemRarityID.Red;
+			Item.rare = ModContent.RarityType<AlephR>();
 			//Item.UseSound = new SoundStyle("LobotomyCorp/Sounds/Item/NothingThere_Goodbye");
             Item.autoReuse = true;
             Item.noMelee = true;

--- a/Items/Ruina/LifeForADaredevilR.cs
+++ b/Items/Ruina/LifeForADaredevilR.cs
@@ -34,7 +34,7 @@ namespace LobotomyCorp.Items.Ruina
 			Item.useStyle = 1;// ItemUseStyleID.Shoot;
 			Item.knockBack = 6;
 			Item.value = 10000;
-			Item.rare = 3;
+			Item.rare = ModContent.RarityType<HeR>();
 
 			Item.shootSpeed = 1f;
 			Item.shoot = ModContent.ProjectileType<Projectiles.Realized.LifeForADaredevilR>();

--- a/Items/Ruina/Literature/BlackSwanR.cs
+++ b/Items/Ruina/Literature/BlackSwanR.cs
@@ -38,7 +38,7 @@ namespace LobotomyCorp.Items.Ruina.Literature
 			Item.UseSound = SoundID.Item1;
 			Item.autoReuse = true;
 			Item.channel = true;
-			Item.rare = ItemRarityID.Yellow;
+			Item.rare = ModContent.RarityType<WawR>();
 
 			Item.shoot = ModContent.ProjectileType<Projectiles.Realized.BlackSwanR>();
 			Item.shootSpeed = 4f;

--- a/Items/Ruina/Literature/LaetitiaR.cs
+++ b/Items/Ruina/Literature/LaetitiaR.cs
@@ -40,7 +40,7 @@ namespace LobotomyCorp.Items.Ruina.Literature
             Item.noUseGraphic = true;
 			Item.UseSound = SoundID.Item1;
 			Item.autoReuse = true;
-			Item.rare = ItemRarityID.Yellow;
+			Item.rare = ModContent.RarityType<HeR>();
 
 			Item.shoot = ModContent.ProjectileType<Projectiles.Realized.LaetitiaR>();
 			Item.shootSpeed = 6f;

--- a/Items/Ruina/Literature/RedEyesR.cs
+++ b/Items/Ruina/Literature/RedEyesR.cs
@@ -37,7 +37,7 @@ namespace LobotomyCorp.Items.Ruina.Literature
             Item.noUseGraphic = false;
 			Item.UseSound = null;//SoundID.Item1;
 			Item.autoReuse = true;
-			Item.rare = ItemRarityID.Yellow;
+			Item.rare = ModContent.RarityType<TethR>();
 
 			Item.shoot = ModContent.ProjectileType<Projectiles.Realized.Spiderbud>();
 			Item.shootSpeed = 1f;

--- a/Items/Ruina/Literature/SanguineDesireR.cs
+++ b/Items/Ruina/Literature/SanguineDesireR.cs
@@ -37,7 +37,7 @@ namespace LobotomyCorp.Items.Ruina.Literature
             Item.noUseGraphic = true;
 			//Item.UseSound = SoundID.Item1;
 			Item.autoReuse = true;
-			Item.rare = ItemRarityID.Yellow;
+			Item.rare = ModContent.RarityType<HeR>();
 
 			Item.shoot = ModContent.ProjectileType<Projectiles.Realized.SanguineDesireR>();
 			Item.shootSpeed = 16f;

--- a/Items/Ruina/Literature/TodaysExpressionR.cs
+++ b/Items/Ruina/Literature/TodaysExpressionR.cs
@@ -37,7 +37,7 @@ namespace LobotomyCorp.Items.Ruina.Literature
             Item.noUseGraphic = true;
 			//Item.UseSound = SoundID.Item1;
 			Item.autoReuse = true;
-			Item.rare = ItemRarityID.Yellow;
+			Item.rare = ModContent.RarityType<TethR>();
 
 			Item.shoot = ModContent.ProjectileType<Projectiles.Realized.TodaysExpressionWall>();
 			Item.shootSpeed = 16f;

--- a/Items/Ruina/Natural/GoldRushR.cs
+++ b/Items/Ruina/Natural/GoldRushR.cs
@@ -35,7 +35,7 @@ namespace LobotomyCorp.Items.Ruina.Natural
 			Item.noMelee = true;
 			Item.knockBack = 4;
 			Item.value = 10000; 
-			Item.rare = ItemRarityID.Purple;
+			Item.rare = ModContent.RarityType<WawR>();
         }
     }
 }

--- a/Items/Ruina/Natural/InTheNameOfLoveAndHateR.cs
+++ b/Items/Ruina/Natural/InTheNameOfLoveAndHateR.cs
@@ -38,7 +38,7 @@ namespace LobotomyCorp.Items.Ruina.Natural
 			Item.noMelee = true;
 			Item.knockBack = 4;
 			Item.value = 10000; 
-			Item.rare = ItemRarityID.Green;
+			Item.rare = ModContent.RarityType<WawR>();
             Item.noUseGraphic = true;
 			//Item.UseSound = SoundID.Item11;
             Item.autoReuse = true;

--- a/Items/Ruina/Natural/NihilR.cs
+++ b/Items/Ruina/Natural/NihilR.cs
@@ -37,6 +37,7 @@ namespace LobotomyCorp.Items.Ruina.Natural
 			Item.UseSound = SoundID.Item11; 
 			Item.autoReuse = true;
             Item.channel = true;
+            Item.rare = ModContent.RarityType<AlephR>();
         }
 
         public override void HoldItem(Player player)

--- a/Items/Ruina/Natural/SwordSharpenedWithTearsR.cs
+++ b/Items/Ruina/Natural/SwordSharpenedWithTearsR.cs
@@ -38,7 +38,7 @@ namespace LobotomyCorp.Items.Ruina.Natural
 			Item.useStyle = ItemUseStyleID.Shoot;
 			Item.knockBack = 6;
 			Item.value = 10000;
-			Item.rare = 2;
+			Item.rare = ModContent.RarityType<WawR>();
 			Item.UseSound = SoundID.Item1;
             Item.noMelee = true;
             Item.noUseGraphic = true;

--- a/Items/Ruina/Philosophy/BeakR.cs
+++ b/Items/Ruina/Philosophy/BeakR.cs
@@ -37,7 +37,7 @@ namespace LobotomyCorp.Items.Ruina.Philosophy
 			Item.useStyle = 1;
 			Item.knockBack = 0.1f;
 			Item.value = 10000;
-			Item.rare = 2;
+			Item.rare = ModContent.RarityType<TethR>();
 			Item.UseSound = SoundID.Item1;
 			Item.autoReuse = true;
 		}

--- a/Items/Ruina/Social/TheHomingInstinctS.cs
+++ b/Items/Ruina/Social/TheHomingInstinctS.cs
@@ -36,7 +36,7 @@ namespace LobotomyCorp.Items.Ruina.Social
             Item.noMelee = true; //so the Item's animation doesn't do damage
             Item.knockBack = 4; // Sets the Item's knockback. Note that projectiles shot by this weapon will use its and the used ammunition's knockback damageed together.
             Item.value = 10000; // how much the Item sells for (measured in copper)
-            Item.rare = ItemRarityID.Purple; // the color that the Item's name will be in-game
+            Item.rare = ModContent.RarityType<HeR>(); // the color that the Item's name will be in-game
             Item.UseSound = SoundID.Item11; // The sound that this Item plays when used.
             Item.autoReuse = true; // if you can hold click to automatically use it again
             Item.shoot = ModContent.ProjectileType<Projectiles.HOUSE>();

--- a/Items/Ruina/Technology/GrinderMk52R.cs
+++ b/Items/Ruina/Technology/GrinderMk52R.cs
@@ -30,7 +30,7 @@ namespace LobotomyCorp.Items.Ruina.Technology
 			Item.useStyle = ItemUseStyleID.Shoot;
 			Item.knockBack = 2;
 			Item.value = 10000;
-			Item.rare = ItemRarityID.Yellow;
+			Item.rare = ModContent.RarityType<HeR>();
 			Item.UseSound = SoundID.Item1;
             Item.noMelee = true;
             Item.noUseGraphic = true;

--- a/Items/Ruina/Technology/HarmonyR.cs
+++ b/Items/Ruina/Technology/HarmonyR.cs
@@ -35,7 +35,7 @@ namespace LobotomyCorp.Items.Ruina.Technology
 			Item.useStyle = ItemUseStyleID.Shoot;
 			Item.knockBack = 6;
 			Item.value = 10000;
-			Item.rare = 3;
+			Item.rare = ModContent.RarityType<HeR>();
             Item.shootSpeed = 3.7f;
             Item.shoot = ModContent.ProjectileType<Projectiles.HarmonyS>();
 

--- a/Items/Ruina/Technology/MagicBulletR.cs
+++ b/Items/Ruina/Technology/MagicBulletR.cs
@@ -37,7 +37,7 @@ namespace LobotomyCorp.Items.Ruina.Technology
 			Item.useStyle = ItemUseStyleID.Shoot;
 			Item.knockBack = 6;
 			Item.value = 10000;
-			Item.rare = ItemRarityID.Purple;
+			Item.rare = ModContent.RarityType<WawR>();
 			//Item.UseSound = SoundID.Item11;
 			Item.noMelee = true;
 			Item.noUseGraphic = true;

--- a/Items/Ruina/Technology/RegretR.cs
+++ b/Items/Ruina/Technology/RegretR.cs
@@ -40,7 +40,7 @@ namespace LobotomyCorp.Items.Ruina.Technology
 			Item.useStyle = ItemUseStyleID.Shoot;
 			Item.knockBack = 6;
 			Item.value = 10000;
-			Item.rare = ItemRarityID.Yellow;
+			Item.rare = ModContent.RarityType<TethR>();
 			Item.UseSound = SoundID.Item1;
             Item.noMelee = true;
             Item.noUseGraphic = true;

--- a/Items/Ruina/Technology/SolemnLamentR.cs
+++ b/Items/Ruina/Technology/SolemnLamentR.cs
@@ -56,7 +56,7 @@ namespace LobotomyCorp.Items.Ruina.Technology
             Item.useStyle = ItemUseStyleID.Shoot;
 			Item.knockBack = 0;
 			Item.value = 10000;
-			Item.rare = 2;
+			Item.rare = ModContent.RarityType<WawR>();
             Item.shootSpeed = 9f;
             Item.shoot = 1;
             Item.useAmmo = AmmoID.Bullet;

--- a/Items/Teth/Beak.cs
+++ b/Items/Teth/Beak.cs
@@ -23,7 +23,7 @@ namespace LobotomyCorp.Items.Teth
 
             Item.noMelee = true;
             Item.value = 7500;
-            Item.rare = ItemRarityID.Blue;
+            Item.rare = ModContent.RarityType<TethB>();
             Item.UseSound = LobotomyCorp.WeaponSounds.Gun;
             Item.autoReuse = true;
 

--- a/Items/Teth/CherryBlossoms.cs
+++ b/Items/Teth/CherryBlossoms.cs
@@ -21,7 +21,7 @@ namespace LobotomyCorp.Items.Teth
             Item.noMelee = true;
             Item.knockBack = 2.4f;
             Item.value = 10000;
-            Item.rare = ItemRarityID.Blue;
+            Item.rare = ModContent.RarityType<TethB>();
             Item.UseSound = LobotomyCorp.WeaponSound("sakura");
             Item.autoReuse = true;
             Item.shoot = ModContent.ProjectileType<Projectiles.CherryBlossomsPetal>();

--- a/Items/Teth/EngulfingDream.cs
+++ b/Items/Teth/EngulfingDream.cs
@@ -30,7 +30,7 @@ namespace LobotomyCorp.Items.Teth
             Item.noMelee = true;
             Item.knockBack = 0;
             Item.value = 10000;
-            Item.rare = ItemRarityID.Blue;
+            Item.rare = ModContent.RarityType<TethB>();
             Item.UseSound = new SoundStyle("LobotomyCorp/Sounds/Item/LWeapons/Dreamy", 2) with { Volume = 0.5f, MaxInstances = 1, SoundLimitBehavior = SoundLimitBehavior.IgnoreNew };
             Item.autoReuse = true;
             Item.shoot = ModContent.ProjectileType<Projectiles.EngulfingDreamCall>();

--- a/Items/Teth/FourthMatchFlame.cs
+++ b/Items/Teth/FourthMatchFlame.cs
@@ -28,7 +28,7 @@ namespace LobotomyCorp.Items.Teth
             Item.noMelee = true; //so the Item's animation doesn't do damage
             Item.knockBack = 4; // Sets the Item's knockback. Note that projectiles shot by this weapon will use its and the used ammunition's knockback damageed together.
             Item.value = 10000; // how much the Item sells for (measured in copper)
-            Item.rare = ItemRarityID.Blue; // the color that the Item's name will be in-game
+            Item.rare = ModContent.RarityType<TethB>(); // the color that the Item's name will be in-game
             Item.UseSound = LobotomyCorp.WeaponSounds.Cannon; // The sound that this Item plays when used.
             Item.autoReuse = true; // if you can hold click to automatically use it again
             Item.shoot = 10; //idk why but all the guns in the vanilla source have this

--- a/Items/Teth/FragmentsFromSomewhere.cs
+++ b/Items/Teth/FragmentsFromSomewhere.cs
@@ -29,7 +29,7 @@ namespace LobotomyCorp.Items.Teth
             Item.useStyle = ItemUseStyleID.Shoot;
             Item.knockBack = 6;
             Item.value = 10000;
-            Item.rare = ItemRarityID.Blue;
+            Item.rare = ModContent.RarityType<TethB>();
             Item.shootSpeed = 3.7f;
             Item.shoot = ModContent.ProjectileType<Projectiles.FragmentsFromSomewhere>();
 

--- a/Items/Teth/Horn.cs
+++ b/Items/Teth/Horn.cs
@@ -30,7 +30,7 @@ namespace LobotomyCorp.Items.Teth
             Item.useStyle = ItemUseStyleID.Shoot;
             Item.knockBack = 6;
             Item.value = 10000;
-            Item.rare = ItemRarityID.Blue;
+            Item.rare = ModContent.RarityType<TethB>();
             Item.shootSpeed = 3.7f;
             Item.shoot = ModContent.ProjectileType<Projectiles.Horn>();
 

--- a/Items/Teth/Lantern.cs
+++ b/Items/Teth/Lantern.cs
@@ -16,7 +16,7 @@ namespace LobotomyCorp.Items.Teth
             Item.useStyle = 15;
             Item.knockBack = 6;
             Item.value = 10000;
-            Item.rare = ItemRarityID.Blue;
+            Item.rare = ModContent.RarityType<TethB>();
             SwingSound = LobotomyCorp.WeaponSounds.Hammer;
             Item.autoReuse = true;
             EGORiskLevel = RiskLevel.Teth;

--- a/Items/Teth/RedEyes.cs
+++ b/Items/Teth/RedEyes.cs
@@ -25,7 +25,7 @@ namespace LobotomyCorp.Items.Teth
             Item.useStyle = 15;
             Item.knockBack = 6;
             Item.value = 10000;
-            Item.rare = ItemRarityID.Blue;
+            Item.rare = ModContent.RarityType<TethB>();
             Item.UseSound = LobotomyCorp.WeaponSounds.Mace;
             Item.autoReuse = true;
             Item.scale = 1.3f;

--- a/Items/Teth/Regret.cs
+++ b/Items/Teth/Regret.cs
@@ -24,7 +24,7 @@ namespace LobotomyCorp.Items.Teth
             Item.useStyle = 15;
             Item.knockBack = 6;
             Item.value = 10000;
-            Item.rare = ItemRarityID.Blue;
+            Item.rare = ModContent.RarityType<TethB>();
             SwingSound = LobotomyCorp.WeaponSounds.Hammer;
             Item.autoReuse = true;
             EGORiskLevel = RiskLevel.Teth;

--- a/Items/Teth/RegretSuit.cs
+++ b/Items/Teth/RegretSuit.cs
@@ -28,7 +28,7 @@ namespace LobotomyCorp.Items.Teth
             Item.height = 40;
             Item.useTime = 56;
             Item.value = 10000;
-            Item.rare = ItemRarityID.Blue;
+            Item.rare = ModContent.RarityType<TethB>();
             Item.defense = 6;
             EGORiskLevel = RiskLevel.Teth;
         }
@@ -49,7 +49,7 @@ namespace LobotomyCorp.Items.Teth
             Item.height = 40;
             Item.useTime = 56;
             Item.value = 10000;
-            Item.rare = ItemRarityID.Blue;
+            Item.rare = ModContent.RarityType<TethB>();
             Item.defense = 6;
             EGORiskLevel = RiskLevel.Teth;
         }
@@ -65,7 +65,7 @@ namespace LobotomyCorp.Items.Teth
             Item.height = 40;
             Item.useTime = 56;
             Item.value = 10000;
-            Item.rare = ItemRarityID.Blue;
+            Item.rare = ModContent.RarityType<TethB>();
             Item.defense = 6;
             EGORiskLevel = RiskLevel.Teth;
         }

--- a/Items/Teth/SoCute.cs
+++ b/Items/Teth/SoCute.cs
@@ -22,7 +22,7 @@ namespace LobotomyCorp.Items.Teth
             Item.useAnimation = 12;
             Item.useTime = 12;
             Item.autoReuse = true;
-            Item.rare = ItemRarityID.Blue;
+            Item.rare = ModContent.RarityType<TethB>();
             Item.UseSound = LobotomyCorp.WeaponSounds.Fist;
             EGORiskLevel = RiskLevel.Teth;
 

--- a/Items/Teth/Solitude.cs
+++ b/Items/Teth/Solitude.cs
@@ -25,7 +25,7 @@ namespace LobotomyCorp.Items.Teth
             Item.noMelee = true;
             Item.knockBack = 4;
             Item.value = 10000;
-            Item.rare = ItemRarityID.Blue;
+            Item.rare = ModContent.RarityType<TethB>();
             Item.UseSound = LobotomyCorp.WeaponSounds.Revolver;
             Item.autoReuse = true;
             Item.shoot = 10;

--- a/Items/Teth/TodaysExpression.cs
+++ b/Items/Teth/TodaysExpression.cs
@@ -27,7 +27,7 @@ namespace LobotomyCorp.Items.Teth
             Item.noMelee = true;
             Item.knockBack = 4;
             Item.value = 10000;
-            Item.rare = ItemRarityID.Blue;
+            Item.rare = ModContent.RarityType<TethB>();
             Item.UseSound = LobotomyCorp.WeaponSounds.Gun;
             Item.autoReuse = true;
             Item.shoot = 10;

--- a/Items/Teth/Tough.cs
+++ b/Items/Teth/Tough.cs
@@ -25,7 +25,7 @@ namespace LobotomyCorp.Items.Teth
             Item.noMelee = true;
             Item.knockBack = 4;
             Item.value = 10000;
-            Item.rare = ItemRarityID.Blue;
+            Item.rare = ModContent.RarityType<TethB>();
             Item.UseSound = LobotomyCorp.WeaponSounds.Gun;
             Item.autoReuse = true;
             Item.shoot = 10;

--- a/Items/Teth/WristCutter.cs
+++ b/Items/Teth/WristCutter.cs
@@ -19,7 +19,7 @@ namespace LobotomyCorp.Items.Teth
             Item.CloneDefaults(ItemID.CopperShortsword);
             Item.shoot = ModContent.ProjectileType<Projectiles.WristCutter>();
             Item.damage = 16;
-            Item.rare = ItemRarityID.Blue;
+            Item.rare = ModContent.RarityType<TethB>();
             Item.UseSound = LobotomyCorp.WeaponSounds.Dagger;
             EGORiskLevel = RiskLevel.Teth;
         }

--- a/Items/Tools/BehaviorAdjustment.cs
+++ b/Items/Tools/BehaviorAdjustment.cs
@@ -27,7 +27,7 @@ namespace LobotomyCorp.Items.Tools
             Item.height = 28;
             Item.accessory = true;
             Item.value = 1000;
-            Item.rare = 1;
+            Item.rare = RarityType<TethB>();
         }
 
         public override void UpdateAccessory(Player player, bool hideVisual)

--- a/Items/Tools/HeartOfAspiration.cs
+++ b/Items/Tools/HeartOfAspiration.cs
@@ -29,7 +29,7 @@ namespace LobotomyCorp.Items.Tools
             Item.height = 28;
             Item.accessory = true;
             Item.value = 1000;
-            Item.rare = 1;
+            Item.rare = RarityType<TethB>();
         }
 
         public override void UpdateAccessory(Player player, bool hideVisual)

--- a/Items/Tools/LuminousBracelet.cs
+++ b/Items/Tools/LuminousBracelet.cs
@@ -27,7 +27,7 @@ namespace LobotomyCorp.Items.Tools
             Item.height = 28;
             Item.accessory = true;
             Item.value = 1000;
-            Item.rare = 1;
+            Item.rare = RarityType<TethB>();
         }
 
         public override void UpdateAccessory(Player player, bool hideVisual)

--- a/Items/Waw/Amrita.cs
+++ b/Items/Waw/Amrita.cs
@@ -29,7 +29,7 @@ namespace LobotomyCorp.Items.Waw
             Item.useStyle = ItemUseStyleID.Shoot;
             Item.knockBack = 6;
             Item.value = 20000;
-            Item.rare = ItemRarityID.Purple;
+            Item.rare = ModContent.RarityType<WawB>();
             Item.shootSpeed = 3f;
             Item.shoot = ModContent.ProjectileType<Projectiles.Amrita>();
 

--- a/Items/Waw/BlackSwan.cs
+++ b/Items/Waw/BlackSwan.cs
@@ -31,7 +31,7 @@ namespace LobotomyCorp.Items.Waw
             Item.useStyle = 15;
 
             Item.value = 10000;
-            Item.rare = ItemRarityID.Purple;
+            Item.rare = ModContent.RarityType<WawB>();
             Item.UseSound = LobotomyCorp.WeaponSound("blackSwan", false, 2);
             Item.autoReuse = true;
 

--- a/Items/Waw/CobaltScar.cs
+++ b/Items/Waw/CobaltScar.cs
@@ -23,7 +23,7 @@ namespace LobotomyCorp.Items.Waw
             Item.useTime = 30;
             Item.useAnimation = 30;
             Item.useStyle = 15;
-            Item.rare = ItemRarityID.Purple;
+            Item.rare = ModContent.RarityType<WawB>();
             Item.scale = 1.2f;
             Item.UseSound = new SoundStyle("LobotomyCorp/Sounds/Item/Wolf_Scratch") with { Volume = 0.5f, PitchVariance = 0.1f };
             EGORiskLevel = RiskLevel.Waw;

--- a/Items/Waw/CrimsonScar.cs
+++ b/Items/Waw/CrimsonScar.cs
@@ -35,7 +35,7 @@ namespace LobotomyCorp.Items.Waw
             Item.width = 34;
             Item.height = 32;
             Item.value = 3000;
-            Item.rare = ItemRarityID.Purple;
+            Item.rare = ModContent.RarityType<WawB>();
             Item.damage = 58;
             Item.knockBack = 3f;
             Item.shootSpeed = 12f;

--- a/Items/Waw/Diffraction.cs
+++ b/Items/Waw/Diffraction.cs
@@ -24,7 +24,7 @@ namespace LobotomyCorp.Items.Waw
             Item.useStyle = 15;
             Item.knockBack = 6;
             Item.value = 5000;
-            Item.rare = ItemRarityID.Purple;
+            Item.rare = ModContent.RarityType<WawB>();
             Item.UseSound = LobotomyCorp.WeaponSounds.Mace;
             Item.autoReuse = true;
             EGORiskLevel = RiskLevel.Waw;

--- a/Items/Waw/Discord.cs
+++ b/Items/Waw/Discord.cs
@@ -30,7 +30,7 @@ namespace LobotomyCorp.Items.Waw
             Item.useStyle = ItemUseStyleID.Shoot;
             Item.knockBack = 6;
             Item.value = 10000;
-            Item.rare = ItemRarityID.Purple;
+            Item.rare = ModContent.RarityType<WawB>();
             Item.shootSpeed = 10.2f;
             Item.shoot = ModContent.ProjectileType<Projectiles.Discord2>();
 

--- a/Items/Waw/Ecstacy.cs
+++ b/Items/Waw/Ecstacy.cs
@@ -28,7 +28,7 @@ namespace LobotomyCorp.Items.Waw
             Item.noMelee = true;
             Item.knockBack = 2.4f;
             Item.value = 10000;
-            Item.rare = ItemRarityID.Purple;
+            Item.rare = ModContent.RarityType<WawB>();
             Item.UseSound = LobotomyCorp.WeaponSound("Shark");
             Item.autoReuse = true;
             Item.shoot = ModContent.ProjectileType<Projectiles.Candy>();

--- a/Items/Waw/Exuviae.cs
+++ b/Items/Waw/Exuviae.cs
@@ -26,7 +26,7 @@ namespace LobotomyCorp.Items.Waw
             Item.noMelee = true; //so the Item's animation doesn't do damage
             Item.knockBack = 4; // Sets the Item's knockback. Note that projectiles shot by this weapon will use its and the used ammunition's knockback damageed together.
             Item.value = 10000; // how much the Item sells for (measured in copper)
-            Item.rare = ItemRarityID.Purple; // the color that the Item's name will be in-game
+            Item.rare = ModContent.RarityType<WawB>(); // the color that the Item's name will be in-game
             Item.UseSound = LobotomyCorp.WeaponSound("Viscus"); // The sound that this Item plays when used.
             Item.autoReuse = true; // if you can hold click to automatically use it again
             Item.shoot = ModContent.ProjectileType<Projectiles.ExuviaeShot>(); //idk why but all the guns in the vanilla source have this

--- a/Items/Waw/FaintAroma.cs
+++ b/Items/Waw/FaintAroma.cs
@@ -27,7 +27,7 @@ namespace LobotomyCorp.Items.Waw
             Item.noMelee = true;
             Item.knockBack = 4;
             Item.value = 10000;
-            Item.rare = ItemRarityID.Purple;
+            Item.rare = ModContent.RarityType<WawB>();
             Item.UseSound = LobotomyCorp.WeaponSounds.BowGun;
             Item.autoReuse = true;
             Item.shoot = 10;

--- a/Items/Waw/FeatherOfHonor.cs
+++ b/Items/Waw/FeatherOfHonor.cs
@@ -31,7 +31,7 @@ namespace LobotomyCorp.Items.Waw
             Item.noMelee = true;
             Item.knockBack = 2.4f;
             Item.value = 5000;
-            Item.rare = ItemRarityID.Purple;
+            Item.rare = ModContent.RarityType<WawB>();
             //Item.UseSound = SoundID.Item1;
             Item.autoReuse = true;
             Item.shoot = ModContent.ProjectileType<Projectiles.FeatherOfHonor>();

--- a/Items/Waw/GreenStem.cs
+++ b/Items/Waw/GreenStem.cs
@@ -27,7 +27,7 @@ namespace LobotomyCorp.Items.Waw
             Item.useStyle = ItemUseStyleID.Shoot;
             Item.knockBack = 6;
             Item.value = 10000;
-            Item.rare = ItemRarityID.Purple;
+            Item.rare = ModContent.RarityType<WawB>();
             Item.shootSpeed = 4.2f;
             Item.shoot = ModContent.ProjectileType<Projectiles.GreenStem>();
 

--- a/Items/Waw/Heaven.cs
+++ b/Items/Waw/Heaven.cs
@@ -28,7 +28,7 @@ namespace LobotomyCorp.Items.Waw
             Item.useStyle = ItemUseStyleID.Shoot;
             Item.knockBack = 6;
             Item.value = 10000;
-            Item.rare = ItemRarityID.Purple;
+            Item.rare = ModContent.RarityType<WawB>();
             Item.shootSpeed = 3.7f;
             Item.shoot = ModContent.ProjectileType<Projectiles.Heaven>();
 

--- a/Items/Waw/Hornet.cs
+++ b/Items/Waw/Hornet.cs
@@ -29,7 +29,7 @@ namespace LobotomyCorp.Items.Waw
             Item.noMelee = true; //so the Item's animation doesn't do damage
             Item.knockBack = 4; // Sets the Item's knockback. Note that projectiles shot by this weapon will use its and the used ammunition's knockback damageed together.
             Item.value = 10000; // how much the Item sells for (measured in copper)
-            Item.rare = ItemRarityID.Purple; // the color that the Item's name will be in-game
+            Item.rare = ModContent.RarityType<WawB>(); // the color that the Item's name will be in-game
             Item.UseSound = LobotomyCorp.WeaponSounds.Rifle; // The sound that this Item plays when used.
             Item.autoReuse = true; // if you can hold click to automatically use it again
             Item.shoot = 10; //idk why but all the guns in the vanilla source have this

--- a/Items/Waw/Hypocrisy.cs
+++ b/Items/Waw/Hypocrisy.cs
@@ -28,7 +28,7 @@ namespace LobotomyCorp.Items.Waw
             Item.noMelee = true;
             Item.knockBack = 4;
             Item.value = 10000;
-            Item.rare = ItemRarityID.Purple;
+            Item.rare = ModContent.RarityType<WawB>();
             Item.UseSound = LobotomyCorp.WeaponSounds.BowGun;
             Item.autoReuse = true;
             Item.shoot = 10;

--- a/Items/Waw/InTheNameOfLoveAndHate.cs
+++ b/Items/Waw/InTheNameOfLoveAndHate.cs
@@ -28,7 +28,7 @@ namespace LobotomyCorp.Items.Waw
             Item.noMelee = true; //so the Item's animation doesn't do damage
             Item.knockBack = 4; // Sets the Item's knockback. Note that projectiles shot by this weapon will use its and the used ammunition's knockback damageed together.
             Item.value = 10000; // how much the Item sells for (measured in copper)
-            Item.rare = ItemRarityID.Purple; // the color that the Item's name will be in-game
+            Item.rare = ModContent.RarityType<WawB>(); // the color that the Item's name will be in-game
             Item.UseSound = LobotomyCorp.WeaponSound("magicalGirl"); // The sound that this Item plays when used.
             Item.autoReuse = true; // if you can hold click to automatically use it again
             Item.shoot = ModContent.ProjectileType<Projectiles.StarShot>(); //idk why but all the guns in the vanilla source have this

--- a/Items/Waw/Lamp.cs
+++ b/Items/Waw/Lamp.cs
@@ -26,7 +26,7 @@ namespace LobotomyCorp.Items.Waw
             Item.useStyle = 15;
             Item.knockBack = 6;
             Item.value = 10000;
-            Item.rare = ItemRarityID.Purple;
+            Item.rare = ModContent.RarityType<WawB>();
             SwingSound = LobotomyCorp.WeaponSounds.Hammer;
             Item.autoReuse = true;
             EGORiskLevel = RiskLevel.Waw;

--- a/Items/Waw/MagicBullet.cs
+++ b/Items/Waw/MagicBullet.cs
@@ -27,7 +27,7 @@ namespace LobotomyCorp.Items.Waw
             Item.noMelee = true; //so the Item's animation doesn't do damage
             Item.knockBack = 1.5f; // Sets the Item's knockback. Note that projectiles shot by this weapon will use its and the used ammunition's knockback damageed together.
             Item.value = 10000; // how much the Item sells for (measured in copper)
-            Item.rare = ItemRarityID.Purple; // the color that the Item's name will be in-game
+            Item.rare = ModContent.RarityType<WawB>(); // the color that the Item's name will be in-game
             Item.UseSound = new SoundStyle("LobotomyCorp/Sounds/Item/Freischutz_Shot") with { Volume = 0.25f }; // The sound that this Item plays when used.
             Item.autoReuse = true; // if you can hold click to automatically use it again
             Item.shoot = 10; //idk why but all the guns in the vanilla source have this

--- a/Items/Waw/Moonlight.cs
+++ b/Items/Waw/Moonlight.cs
@@ -26,7 +26,7 @@ namespace LobotomyCorp.Items.Waw
             Item.useStyle = 15;
             Item.knockBack = 6;
             Item.value = 10000;
-            Item.rare = ItemRarityID.Purple;
+            Item.rare = ModContent.RarityType<WawB>();
             Item.UseSound = LobotomyCorp.WeaponSound("blackSwan1");
             Item.autoReuse = true;
             EGORiskLevel = RiskLevel.Waw;

--- a/Items/Waw/Pleasure.cs
+++ b/Items/Waw/Pleasure.cs
@@ -28,7 +28,7 @@ namespace LobotomyCorp.Items.Waw
             Item.useStyle = ItemUseStyleID.Shoot;
             Item.knockBack = 6;
             Item.value = 10000;
-            Item.rare = ItemRarityID.Yellow;
+            Item.rare = ModContent.RarityType<HeB>();
             Item.shootSpeed = 10.3f;
             Item.shoot = ModContent.ProjectileType<Projectiles.PleasureSpear>();
 

--- a/Items/Waw/SolemnLament.cs
+++ b/Items/Waw/SolemnLament.cs
@@ -28,7 +28,7 @@ namespace LobotomyCorp.Items.Waw
             Item.width = 32;
             Item.height = 32;
             Item.value = 3000;
-            Item.rare = ItemRarityID.Purple;
+            Item.rare = ModContent.RarityType<WawB>();
             Item.damage = 32;
             Item.shootSpeed = 12f;
             Item.shoot = 10;

--- a/Items/Waw/Spore.cs
+++ b/Items/Waw/Spore.cs
@@ -28,7 +28,7 @@ namespace LobotomyCorp.Items.Waw
             Item.useStyle = ItemUseStyleID.Shoot;
             Item.knockBack = 6;
             Item.value = 10000;
-            Item.rare = ItemRarityID.Purple;
+            Item.rare = ModContent.RarityType<WawB>();
             Item.shootSpeed = 4.7f;
             Item.shoot = ModContent.ProjectileType<Projectiles.Spore>();
 

--- a/Items/Waw/SwordSharpenedWithTears.cs
+++ b/Items/Waw/SwordSharpenedWithTears.cs
@@ -29,7 +29,7 @@ namespace LobotomyCorp.Items.Waw
             Item.useStyle = ItemUseStyleID.Shoot;
             Item.knockBack = 6;
             Item.value = 10000;
-            Item.rare = ItemRarityID.Purple;
+            Item.rare = ModContent.RarityType<WawB>();
             Item.shootSpeed = 3.2f;
             Item.shoot = ModContent.ProjectileType<Projectiles.SwordSharpenedWithTearsProj>();
 

--- a/Items/Zayin/Penitence.cs
+++ b/Items/Zayin/Penitence.cs
@@ -30,7 +30,7 @@ namespace LobotomyCorp.Items.Zayin
             Item.useStyle = 15;
             Item.knockBack = 6;
             Item.value = 10000;
-            Item.rare = ItemRarityID.Green;
+            Item.rare = ModContent.RarityType<ZayinB>();
             Item.UseSound = LobotomyCorp.WeaponSounds.Mace;
             Item.autoReuse = true;
             Item.shoot = ModContent.ProjectileType<PenitencePlayerSwing>();

--- a/Items/Zayin/Soda.cs
+++ b/Items/Zayin/Soda.cs
@@ -26,7 +26,7 @@ namespace LobotomyCorp.Items.Zayin
             Item.noMelee = true;
             Item.knockBack = 4;
             Item.value = 10000;
-            Item.rare = ItemRarityID.Green;
+            Item.rare = ModContent.RarityType<ZayinB>();
             Item.UseSound = LobotomyCorp.WeaponSounds.Gun;
             Item.autoReuse = true;
             Item.shoot = 10;

--- a/Items/Zayin/Wingbeat.cs
+++ b/Items/Zayin/Wingbeat.cs
@@ -29,7 +29,7 @@ namespace LobotomyCorp.Items.Zayin
             Item.useStyle = 15;
             Item.knockBack = 6;
             Item.value = 10000;
-            Item.rare = ItemRarityID.Green;
+            Item.rare = ModContent.RarityType<ZayinB>();
             Item.UseSound = LobotomyCorp.WeaponSounds.Mace;
             Item.autoReuse = true;
             Item.shoot = ModContent.ProjectileType<WingbeatSlash>();

--- a/LobotomyRarities.cs
+++ b/LobotomyRarities.cs
@@ -1,0 +1,90 @@
+using Microsoft.Xna.Framework;
+using Terraria.ModLoader;
+
+namespace LobotomyCorp
+{
+	public class ZayinB : ModRarity // B - Base
+	{
+		public override Color RarityColor => new(150, 255, 150); // Color of the Green Rarity (2)
+
+		public override int GetPrefixedRarity(int offset, float valueMult) {
+			return Type;
+            // Makes it so reforges don't affect the rarity
+		}
+	}
+	public class TethB : ModRarity
+	{
+		public override Color RarityColor => new(150, 150, 255); // Color of the Blue Rarity (1)
+
+		public override int GetPrefixedRarity(int offset, float valueMult) {
+			return Type;
+		}
+	}
+	public class HeB : ModRarity
+	{
+		public override Color RarityColor => new(255, 255, 150); // Color of the Yellow Rarity (8)
+		// also made it less vibrant so its different from the realization color
+
+		public override int GetPrefixedRarity(int offset, float valueMult) {
+			return Type;
+		}
+	}
+	public class WawB : ModRarity
+	{
+		public override Color RarityColor => new(180, 40, 255); // Color of the Purple Rarity (11)
+		// also made it less vibrant so its different from the realization color
+
+		public override int GetPrefixedRarity(int offset, float valueMult) {
+			return Type;
+		}
+	}
+	public class AlephB : ModRarity
+	{
+		public override Color RarityColor => new(255, 40, 100); // Color of the Red Rarity (10)
+		// also made it less vibrant so its different from the realization color
+
+		public override int GetPrefixedRarity(int offset, float valueMult) {
+			return Type;
+		}
+	}
+	public class ZayinR : ModRarity // R - Realized
+	{
+		public override Color RarityColor => LobotomyCorp.ZayinRarity;
+
+		public override int GetPrefixedRarity(int offset, float valueMult) {
+			return Type;
+		}
+	}
+	public class TethR : ModRarity
+	{
+		public override Color RarityColor => LobotomyCorp.TethRarity;
+
+		public override int GetPrefixedRarity(int offset, float valueMult) {
+			return Type;
+		}
+	}
+	public class HeR : ModRarity
+	{
+		public override Color RarityColor => LobotomyCorp.HeRarity;
+
+		public override int GetPrefixedRarity(int offset, float valueMult) {
+			return Type;
+		}
+	}
+	public class WawR : ModRarity
+	{
+		public override Color RarityColor => LobotomyCorp.WawRarity;
+
+		public override int GetPrefixedRarity(int offset, float valueMult) {
+			return Type;
+		}
+	}
+	public class AlephR : ModRarity
+	{
+		public override Color RarityColor => LobotomyCorp.AlephRarity;
+
+		public override int GetPrefixedRarity(int offset, float valueMult) {
+			return Type;
+		}
+	}
+}

--- a/build.txt
+++ b/build.txt
@@ -1,3 +1,3 @@
 displayName = Lobotomy Corporation
 author = Kerubii
-version = 0.8.9
+version = 0.8.10


### PR DESCRIPTION
This Pull Request reworks the rarity system to use custom rarities. This will fix the problems listed below.
The old ModifyTooltips weren't removed, and the colors haven't been changed. (except for base HE weapons)
## Reforges changing Rarity
Getting a bad or good reforge on an item will change their rarity, making WAW weapons cyan instead of purple for example.
These custom rarities have been programmed to not be affected by this.
![20250421173621_1](https://github.com/user-attachments/assets/af30dbdc-70a4-47c2-95ee-b897de02175f)
## Item Rarities in Non-Tooltip Environments
Even the Realized EGOs have issues, since ModifyTooltips only modifies tooltips, other environments where item names are displayed will have incorrect name colors.
These custom rarities make sure they have correct colors everywhere.
![20250421173610_1](https://github.com/user-attachments/assets/0a8a0189-fcd5-4cd2-9969-8b99d36f43ad)
![20250421173623_1](https://github.com/user-attachments/assets/4f8c518c-c6ed-41ca-a7b4-a5c427a2f408)
## HE EGOs having the same color when realized
HE EGOs now have a fainter color than their realized counterparts, just like ZAYIN and TETH EGOs.
![20250421181821_1](https://github.com/user-attachments/assets/81c91f98-ada6-4224-8266-144586554bd2)
